### PR TITLE
feat: added code for mobile navigation and styled it using css

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,22 @@
             </ul>
         </div>
      </nav>
+     <nav id="hamburger-nav">
+     <div class="logo">Aaska Koirala</div>
+     <div class="hamburger-menu">
+        <div class="hamburger-icon" onclick="toggleMenu()">
+            <span></span>
+            <span></span>
+            <span></span>
+        </div>
+        <div class="menu-links">
+            <li><a href="#about" onclick="toggleMenu()">About</a></li>
+            <li><a href="#experience" onclick="toggleMenu()">Experience</a></li>
+            <li><a href="#projects" onclick="toggleMenu()">Projects</a></li>
+            <li><a href="#contact" onclick="toggleMenu()">Contact</a></li>
+        </div>
+     </div>
+     </nav>
 <script src="./script.js"></script>
 </body>
 </html>

--- a/mediaqueries.css
+++ b/mediaqueries.css
@@ -1,0 +1,11 @@
+/* This means when the screen size is less than 1200 pixels the desktop navigation will disappear. */
+@media screen and (max-width: 1200px) {
+#desktop-nav{
+    display: none;
+}
+#hamburger-nav{
+    display: flex;
+}
+} 
+
+

--- a/script.js
+++ b/script.js
@@ -1,0 +1,6 @@
+function toogleMenu() {
+    const menu = document.querySelector(".menu-links");
+    const icon = document.querySelector(".hamburger-icon");
+    menu.classList.toggle("open");
+    icon.classList.toggle("open");
+}

--- a/style.css
+++ b/style.css
@@ -65,3 +65,82 @@ a:hover{
 .logo:hover{
     cursor: default;
 }
+/* MOBILE NAVIGATION */
+/* HAMBURGER MENU*/
+
+#hamburger-nav{
+    display: none;
+}
+
+.hamburger-menu{
+    position: relative;
+    display: inline-block;
+}
+
+.hamburger-icon{
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 24px;
+    width: 30px;
+    cursor: pointer;
+}
+
+.hamburger-icon span{
+    width: 100%;
+    height: 2px;
+    background-color: black;
+    transition: all 0.3 ease-in-out;
+}
+
+.menu-links{
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: white;
+    width: fit-content;
+    max-height: 0%;
+    overflow: hidden;
+    transition: all 0.3 ease-in-out;
+}
+
+.menu-links a{
+    display: block;
+    padding: 10px;
+    text-align: center;
+    font-size: 1.5rem;
+    color: black;
+}
+
+.menu-links li{
+    list-style: none;
+}
+
+.menu-links.open{
+    max-height: 300px; /* Adjust based on the number of links */
+}
+
+.hamburger-icon.open span:first-child{
+    transform: rotate(45deg) translate(10px, 5px); 
+    
+}
+
+.hamburger-icon.open span:nth-child(2){
+   opacity: 0;
+}
+
+.hamburger-icon.open span:last-child{
+    transform: rotate(-45deg) translate(10px, -5px); 
+}
+
+.hamburger-icon span:first-child{
+    transform: none;
+}
+
+.hamburger-icon span:first-child{
+   opacity: 1;
+}
+
+.hamburger-icon span:first-child{
+    transform: none;
+}


### PR DESCRIPTION
# In this PR, I have added the code for mobile navigation and styled it using css. 
## Preview: 

<img width="540" height="306" alt="Screenshot 2025-08-08 at 8 44 18 AM" src="https://github.com/user-attachments/assets/4b9cfa16-5cf4-4239-b93a-7042dab1130e" />


## I have used mediaqueries.css also so that, when the screen size is less than 1200 pixels the desktop navigation will disappear.